### PR TITLE
Add filterable concern for models

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    metova (0.0.4)
+    metova (0.0.5)
       devise (>= 3.2.0)
       kaminari (~> 0.16.0)
       rails (~> 4.2.0)

--- a/lib/metova.rb
+++ b/lib/metova.rb
@@ -15,5 +15,7 @@ require 'metova/devise/controller'
 require 'metova/devise/strategies/token_authenticatable'
 require 'metova/devise/models/token_authenticatable'
 
+require 'metova/models/filterable'
+
 module Metova
 end

--- a/lib/metova/models/filterable.rb
+++ b/lib/metova/models/filterable.rb
@@ -3,22 +3,20 @@ module Metova
     module Filterable
       extend ActiveSupport::Concern
 
-      included do
-        scope :filter, ->(target) {
+      module ClassMethods
+        def filter_attributes(arg = nil)
+          @filter_attributes = arg if arg
+          @filter_attributes
+        end
+
+        def filter(target)
           filter_texts = []
           filter_attributes.each do |attr|
             filter_texts << "#{attr} like ?"
           end
           query = [filter_texts.join(' OR ')]
-          filter_texts.count.times{ query << "%#{target}%" }
+          filter_texts.count.times { query << "%#{target}%" }
           where(query)
-        }
-      end
-
-      module ClassMethods
-        def filter_attributes(arg=nil)
-          @filter_attributes = arg if arg
-          @filter_attributes
         end
       end
     end

--- a/lib/metova/models/filterable.rb
+++ b/lib/metova/models/filterable.rb
@@ -9,13 +9,19 @@ module Metova
           @filter_attributes
         end
 
-        def filter(target)
+        def filter(target, *filter_attrs)
+          if filter_attrs.empty?
+            filter_attrs = @filter_attributes
+          end
+
           filter_texts = []
-          filter_attributes.each do |attr|
+          filter_attrs.each do |attr|
             filter_texts << "#{attr} like ?"
           end
+
           query = [filter_texts.join(' OR ')]
           filter_texts.count.times { query << "%#{target}%" }
+
           where(query)
         end
       end

--- a/lib/metova/models/filterable.rb
+++ b/lib/metova/models/filterable.rb
@@ -1,0 +1,26 @@
+module Metova
+  module Models
+    module Filterable
+      extend ActiveSupport::Concern
+
+      included do
+        scope :filter, ->(target) {
+          filter_texts = []
+          filter_attributes.each do |attr|
+            filter_texts << "#{attr} like ?"
+          end
+          query = [filter_texts.join(' OR ')]
+          filter_texts.count.times{ query << "%#{target}%" }
+          where(query)
+        }
+      end
+
+      module ClassMethods
+        def filter_attributes(arg=nil)
+          @filter_attributes = arg if arg
+          @filter_attributes
+        end
+      end
+    end
+  end
+end

--- a/lib/metova/version.rb
+++ b/lib/metova/version.rb
@@ -1,3 +1,3 @@
 module Metova
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end

--- a/spec/controllers/filtering_spec.rb
+++ b/spec/controllers/filtering_spec.rb
@@ -6,11 +6,11 @@ describe Api::PostsController do
     it 'should filter posts based on the query' do
       get :index, user_id: user, query: 'aa'
       expect(json.size).to be 1
-      expect(json.map{ |h| h[:id] }).to match_array [posts(:a).id]
+      expect(json.map { |h| h[:id] }).to match_array [posts(:a).id]
 
       get :index, user_id: user, query: 'bb'
       expect(json.size).to be 1
-      expect(json.map{ |h| h[:id] }).to match_array [posts(:b).id]
+      expect(json.map { |h| h[:id] }).to match_array [posts(:b).id]
     end
   end
 end

--- a/spec/controllers/filtering_spec.rb
+++ b/spec/controllers/filtering_spec.rb
@@ -1,0 +1,16 @@
+describe Api::PostsController do
+  let(:user) { users(:logan) }
+  before { user.update token_expires_at: Time.current + 1.day }
+
+  describe '?query=something filtering' do
+    it 'should filter posts based on the query' do
+      get :index, user_id: user, query: 'aa'
+      expect(json.size).to be 1
+      expect(json.map{ |h| h[:id] }).to match_array [posts(:a).id]
+
+      get :index, user_id: user, query: 'bb'
+      expect(json.size).to be 1
+      expect(json.map{ |h| h[:id] }).to match_array [posts(:b).id]
+    end
+  end
+end

--- a/spec/dummy/app/controllers/api/posts_controller.rb
+++ b/spec/dummy/app/controllers/api/posts_controller.rb
@@ -6,6 +6,7 @@ class Api::PostsController < Api::BaseController
   def index
     user = User.find params[:user_id]
     @posts = user.posts
+    @posts = @posts.filter(params[:query]) if params[:query]
     respond_with @posts
   end
 

--- a/spec/dummy/app/models/post.rb
+++ b/spec/dummy/app/models/post.rb
@@ -1,3 +1,5 @@
 class Post < ActiveRecord::Base
+  include Metova::Models::Filterable
   belongs_to :user
+  filter_attributes %w(title body)
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,9 @@
+describe Post do
+  subject{ posts(:a) }
+  it 'can be filtered' do
+    expect(Post.respond_to?(:filter)).to be_truthy
+    expect(Post.filter('aa')).to match_array [posts(:a)]
+    expect(Post.filter('bb')).to eq [posts(:b)]
+    expect(Post.filter('cc')).to eq [posts(:c)]
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -6,4 +6,9 @@ describe Post do
     expect(Post.filter('bb')).to eq [posts(:b)]
     expect(Post.filter('cc')).to eq [posts(:c)]
   end
+
+  it 'can be filtered with other attributes' do
+    expect(Post.filter('Hey', :title)).to eq [posts(:logan)]
+    expect(Post.filter('Hey', :body)).to eq []
+  end
 end


### PR DESCRIPTION
Scope that constructs a 'LIKE' query based on the attributes you specify.

Usage:

In model:
```ruby
class SomeModel
  include Metova::Models::Filterable
  filter_attributes %w(title body)
end
```

In controller:
```ruby
SomeModel.filter('search text')
```