### PR TITLE
Add support for rails 5 secrets

### DIFF
--- a/lib/metova.rb
+++ b/lib/metova.rb
@@ -14,6 +14,8 @@ require 'metova/versioning/router_dsl'
 require 'metova/versioning/constraints'
 require 'metova/versioning/railtie'
 
+require 'metova/smtp'
+
 require 'metova/devise/controller'
 require 'metova/devise/strategies/token_authenticatable'
 require 'metova/devise/models/token_authenticatable'

--- a/lib/metova/smtp/railtie.rb
+++ b/lib/metova/smtp/railtie.rb
@@ -1,26 +1,50 @@
 module Metova
   module SMTP
     class Railtie < ::Rails::Railtie
+      initializer 'metova.smtp' do |app|
+        next unless address.present? && port.present? && username.present? && password.present?
 
-      initializer "metova.smtp" do |app|
-        if ENV['METOVA_SMTP_USERNAME'] && ENV['METOVA_SMTP_PASSWORD'] && ENV['METOVA_SMTP_ADDRESS'] && ENV['METOVA_SMTP_PORT']
-          app.config.action_mailer.delivery_method = :smtp
-          app.config.action_mailer.default_url_options = { host: ENV['METOVA_SMTP_DEFAULT_HOST'] }
-          app.routes.default_url_options = app.config.action_mailer.default_url_options
-
-          app.config.action_mailer.smtp_settings = {
-            address: ENV['METOVA_SMTP_ADDRESS'],
-            port: ENV['METOVA_SMTP_PORT'],
-            enable_starttls_auto: true,
-            authentication: 'login',
-            user_name: ENV['METOVA_SMTP_USERNAME'],
-            password: ENV['METOVA_SMTP_PASSWORD'],
-          }
-
-          app.config.action_mailer.smtp_settings.merge! domain: ENV['METOVA_SMTP_DOMAIN'] if ENV['METOVA_SMTP_DOMAIN']
-        end
+        app.config.action_mailer.delivery_method = :smtp
+        app.config.action_mailer.smtp_settings = smtp_settings
+        app.config.action_mailer.smtp_settings[:domain] = domain if domain.present?
+        app.routes.default_url_options = app.config.action_mailer.default_url_options = { host: host } if host.present?
       end
 
+      private
+        def smtp_settings
+          @smtp_settings ||= {
+            enable_starttls_auto: true,
+            authentication: 'login',
+            address: address,
+            port: port,
+            username: username,
+            password: password
+          }
+        end
+
+        def domain
+          ENV.fetch 'METOVA_SMTP_DOMAIN', Rails.application.secrets.metova_smtp_domain
+        end
+
+        def host
+          ENV.fetch 'METOVA_SMTP_HOST', Rails.application.secrets.metova_smtp_host
+        end
+
+        def address
+          ENV.fetch 'METOVA_SMTP_ADDRESS', Rails.application.secrets.metova_smtp_address
+        end
+
+        def port
+          ENV.fetch 'METOVA_SMTP_PORT', Rails.application.secrets.metova_smtp_port
+        end
+
+        def username
+          ENV.fetch 'METOVA_SMTP_USERNAME', Rails.application.secrets.metova_smtp_username
+        end
+
+        def password
+          ENV.fetch 'METOVA_SMTP_PASSWORD', Rails.application.secrets.metova_smtp_password
+        end
     end
   end
 end


### PR DESCRIPTION
Adding in support for rails 5 secrets.

The smtp railtie didn't seem to be being loaded at all. Perhaps I'm doing something wrong and the `require` line isn't needed.

I tested this out on a local project. I'm not sure how to add specs to the gem itself, but I'd be happy to, given a little direction.